### PR TITLE
Fix the registering of stylesheets on SeaMonkey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 
 *.xpi
+xulrunner-sdk
+

--- a/create_xpi.sh
+++ b/create_xpi.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+rm extension.xpi
+cd src
+zip -r ../extension.xpi *
+cd ..
+

--- a/generate_xpt
+++ b/generate_xpt
@@ -1,2 +1,2 @@
-~/xulrunner-sdk/sdk/bin/typelib.py --cachedir ~/xpidlcache -I ~/xulrunner-sdk/idl -o ./components/stylishStyle.xpt ./idl/stylishStyle.idl
-~/xulrunner-sdk/sdk/bin/typelib.py --cachedir ~/xpidlcache -I ~/xulrunner-sdk/idl -o ./components/stylishDataSource.xpt ./idl/stylishDataSource.idl
+python2 xulrunner-sdk/sdk/bin/typelib.py --cachedir ./xpidlcache -I ./xulrunner-sdk/idl -o ./src/components/stylishStyle.xpt ./src/idl/stylishStyle.idl
+python2 xulrunner-sdk/sdk/bin/typelib.py --cachedir ./xpidlcache -I ./xulrunner-sdk/idl -o ./src/components/stylishDataSource.xpt ./src/idl/stylishDataSource.idl

--- a/src/components/stylishStyle.js
+++ b/src/components/stylishStyle.js
@@ -588,6 +588,11 @@ Style.prototype = {
 	HTMLNS: "http://www.w3.org/1999/xhtml",
 	ios: Components.classes["@mozilla.org/network/io-service;1"].getService(Components.interfaces.nsIIOService),
 	sss: Components.classes["@mozilla.org/content/style-sheet-service;1"].getService(Components.interfaces.nsIStyleSheetService),
+	console: Components.classes['@mozilla.org/consoleservice;1'].getService(Components.interfaces.nsIConsoleService),
+
+	log: function(str) {
+		this.console.logStringMessage(str)
+	},
 
 	getStyleSheet: function(code) {
 		var parser = Components.classes["@mozilla.org/xmlextras/domparser;1"].createInstance(Components.interfaces.nsIDOMParser);
@@ -695,6 +700,7 @@ Style.prototype = {
 		var nameComment = this.name ? "/*" + this.name.replace(/\*\//g, "").replace(/#/g, "") + "*/" : "";
 		// this will strip new lines rather than escape - not what we want
 		//return this.ios.newURI("data:text/css," + nameComment + this.code.replace(/\n/g, "%0A"), null, null);
+		this.log("data:text/css," + nameComment + encodeURIComponent(this.code));
 		return this.ios.newURI("data:text/css," + nameComment + encodeURIComponent(this.code), null, null);
 	},
 
@@ -710,6 +716,8 @@ Style.prototype = {
 		this.appliedInfo = [dataUrl, registrationMethod];
 		if (!this.sss.sheetRegistered(dataUrl, registrationMethod)) {
 			this.sss.loadAndRegisterSheet(dataUrl, registrationMethod);
+			this.log(this.sss.sheetRegistered(dataUrl, registrationMethod));
+			this.log(registrationMethod);
 		}
 	},
 
@@ -1003,7 +1011,7 @@ Style.prototype = {
 		if (!("AUTHOR_SHEET" in this.sss) || /\/\*\s*AGENT_SHEET\s*\*\//.test(this.code)) {
 			return this.sss.AGENT_SHEET;
 		}
-		return this.sss.AUTHOR_SHEET;
+		return this.sss.USER_SHEET;
 	},
 
 	downloadMd5: function(md5Url, callback) {


### PR DESCRIPTION
I guess I should create another branch with only the appropriate fix, since Github don't allow pull requests from references ( dfab072 [link](https://github.com/Lootyhoof/stylem/commit/dfab07238fd0ab5424a7849622f26625726d3fb3) ).

Anyway : I tried this extension on Seamonkey but the main functionality was broken.

After adding some logs here and there, and checking [Mozilla's (now obsolete) documentation about how to load User Style Sheets from an extension](https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Using_the_Stylesheet_Service), I made **calculateRegistrationMethod** return USER_SHEET instead of AUTHOR_SHEET when creating a stylesheet for websites and... it worked !

That said, it works on Seamonkey, but I haven't tested this on Palemoon and Waterfox, so maybe it breaks things on those browsers.