### PR TITLE
Updates from https://github.com/dirkf/stylem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Stylem - a user style manager for Pale Moon, Interlink and other Mozilla-based software. Install styles from [userstyles.org](https://userstyles.org/) to change how web pages and the application look.
+Stylem - a user style manager for Pale Moon, Interlink, SeaMonkey, and other Mozilla-based software. Install styles from [userstyles.org](https://userstyles.org/) to change how web pages and the application look.
 
 Contributing
 ------------
@@ -24,7 +24,7 @@ License
 
 Copyright (C) 2005-2014 Jason Barnabe <jason.barnabe@gmail.com>
 
-Copyright (C) 2018+ Stylem Contributors
+Copyright (C) 2018-2022 Stylem Contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/components/stylishStyle.js
+++ b/src/components/stylishStyle.js
@@ -22,7 +22,6 @@ function Style() {
 	this._enabled = false;
 
 	this.meta = [];
- 
 
 	this.previewOn = false;
 	this.appliedInfoToBeCalculated = false;
@@ -101,8 +100,10 @@ Style.prototype = {
 		var connection = this.getConnection();
 		var statement = connection.createStatement("SELECT style_id FROM style_meta WHERE style_meta.name = :name AND style_meta.value = :value;");
 		try {
-			this.bind(statement, "name", name);
-			this.bind(statement, "value", value);
+			this.bind(statement, {
+				name: name,
+				value: value
+			});
 			var styles = [];
 			while (statement.executeStep()) {
 				// theoretically we shouldn't find a style that doesn't exist, but who knows?
@@ -209,7 +210,7 @@ Style.prototype = {
 		this.unregister();
 		var connection = this.getConnection();
 		var statement = connection.createStatement("DELETE FROM styles WHERE id = :id;");
-		this.bind(statement, "id", this.id);
+		this.bind(statement, {id: this.id});
 		try {
 			statement.execute();
 		} finally {
@@ -217,7 +218,7 @@ Style.prototype = {
 			statement.finalize();
 		}
 		var statement = connection.createStatement("DELETE FROM style_meta WHERE style_id = :id;");
-		this.bind(statement, "id", this.id);
+		this.bind(statement, {id: this.id});
 		try {
 			statement.execute();
 		} finally {
@@ -238,44 +239,43 @@ Style.prototype = {
 		var newStyle = this.id == 0;
 
 		var that = this;
-		function b(name, value) {
-			that.bind(statement, name, value);
-		}
+		var data = {};
 		if (this.id == 0) {
 			statement = connection.createStatement("INSERT INTO styles (`url`, `idUrl`, `updateUrl`, `md5Url`, `name`, `code`, `enabled`, `originalCode`, `applyBackgroundUpdates`, `originalMd5`) VALUES (:url, :idUrl, :updateUrl, :md5Url, :name, :code, :enabled, :originalCode, :applyBackgroundUpdates, :originalMd5);");
 		} else {
 			statement = connection.createStatement("UPDATE styles SET `url` = :url, `idUrl` = :idUrl, `updateUrl` = :updateUrl, `md5Url` = :md5Url, `name` = :name, `code` = :code, `enabled` = :enabled, `originalCode` = :originalCode, `applyBackgroundUpdates` = :applyBackgroundUpdates, `originalMd5` = :originalMd5 WHERE `id` = :id;");
-			b("id", this.id);
+			data.id = this.id;
 		}
 
 		// style is not updatable, original code is useless
 		if (!this.updateUrl && !this.md5Url) {
 			this.originalCode = null;
-			b("originalCode", this.originalCode);
+			data.originalCode = this.originalCode;
 		// original code matches current code, no need to remember original
 		} else if (this.originalCode == this.code) {
 			this.originalCode = null;
-			b("originalCode", this.originalCode);
+			data.originalCode = this.originalCode;
 		// original code exists and is different, don't touch
 		} else if (this.originalCode) {
-			b("originalCode", this.originalCode);
+			data.originalCode = this.originalCode;
 		// style has changed
 		} else if (this.lastSavedCode != this.code) {
 			this.originalCode = this.lastSavedCode;
-			b("originalCode", this.originalCode);
+			data.originalCode = this.originalCode;
 		} else {
-			b("originalCode", null);
+			data.originalCode = null;
 		}
 
-		b("url", this.url);
-		b("idUrl", this.idUrl);
-		b("updateUrl", this.updateUrl);
-		b("md5Url", this.md5Url);
-		b("name", this.name);
-		b("code", this.code);
-		b("enabled", this.enabled);
-		b("applyBackgroundUpdates", this.applyBackgroundUpdates);
-		b("originalMd5", this.originalMd5);
+		data.url = this.url;
+		data.idUrl = this.idUrl;
+		data.updateUrl = this.updateUrl;
+		data.md5Url = this.md5Url;
+		data.name = this.name;
+		data.code = this.code;
+		data.enabled = this.enabled;
+		data.applyBackgroundUpdates = this.applyBackgroundUpdates;
+		data.originalMd5 = this.originalMd5;
+		this.bind(statement, data);
 
 		try {
 			statement.execute();
@@ -306,16 +306,18 @@ Style.prototype = {
 				//delete the previous calculated meta data
 				if (!newStyle) {
 					statement = connection.createStatement("DELETE FROM style_meta WHERE style_id = :id;");
-					b("id", this.id);
+					this.bind(statement, {id: this.id});
 					statement.execute();
 					statement.finalize();
 				}
 
 				statement = connection.createStatement("INSERT INTO style_meta (`style_id`, `name`, `value`) VALUES (:id, :name, :value);");
 				this.meta.forEach(function(a) {
-					b("id", that.id);
-					b("name", a[0]);
-					b("value", a[1]);
+					that.bind(statement, {
+						id: that.id,
+						name: a[0],
+						value: a[1]
+					});
 					statement.execute();
 				});
 				connection.commitTransaction();
@@ -447,7 +449,7 @@ Style.prototype = {
 
 	checkForUpdates: function(observer) {
 		var that = this;
-		
+
 		var observerService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
 		observerService.notifyObservers(that, "stylem-style-update-check-start", null);
 		if (observer) {
@@ -705,7 +707,7 @@ Style.prototype = {
 		)
 			this.addMeta("type", "global");
 		// everything else is site
-		else 
+		else
 			this.addMeta("type", "site");
 	},
 
@@ -746,7 +748,7 @@ Style.prototype = {
 			unregisterUrl = this.appliedInfo[0];
 			unregisterMethod = this.appliedInfo[1];
 		}
-		
+
 		if (this.sss.sheetRegistered(unregisterUrl, unregisterMethod)) {
 			this.sss.unregisterSheet(unregisterUrl, unregisterMethod);
 		// ignore unregistered styles if stylish isn't on
@@ -756,36 +758,30 @@ Style.prototype = {
 		this.appliedInfo = null;
 	},
 
-	bind: function(statement, name, value) {
-		var index;
-		try {
-			index = statement.getParameterIndex(":" + name);
-		} catch (ex) {
-			if (ex.name == "NS_ERROR_ILLEGAL_VALUE") {
-				index = statement.getParameterIndex(name);
-			} else {
-				throw ex;
+	bind: function(statement, data) {
+		let params = statement.newBindingParamsArray();
+		let binding = params.newBindingParams();
+		for (let [name, value] of Object.entries(data)) {
+			let index;
+			try {
+				index = statement.getParameterIndex(":" + name);
+			} catch (ex) {
+				if (ex.name == "NS_ERROR_ILLEGAL_VALUE") {
+					index = statement.getParameterIndex(name);
+				} else {
+					throw ex;
+				}
 			}
+			if (value === undefined)
+				throw "Attempted to bind undefined parameter '" + name + "'";
+			else if (value !== null && !["string", "number", "boolean"].includes(typeof value))
+				throw "Unknown value type '" + typeof value + "' for value '" + value + "'";
+			if (typeof value === "boolean")
+				value = +value;
+			binding.bindByIndex(index, value);
 		}
-		if (value === undefined)
-			throw "Attempted to bind undefined parameter '" + name + "'";
-		else if (value === null)
-			statement.bindNullParameter(index);
-		else {
-			switch(typeof value) {
-				case "string":
-					statement.bindStringParameter(index, value);
-					break;
-				case "number":
-					statement.bindInt32Parameter(index, value);
-					break;
-				case "boolean":
-					statement.bindInt32Parameter(index, value ? 1 : 0);
-					break;
-				default:
-					throw "Unknown value type '" + typeof value + "' for value '" + value + "'";
-			}
-		}
+		params.addParams(binding);
+    statement.bindParameters(params);
 	},
 
 	extract: function(statement, name) {
@@ -826,9 +822,7 @@ Style.prototype = {
 			closeConnection = true;
 		}
 		var statement = connection.createStatement(sql);
-		for (var i in parameters) {
-			this.bind(statement, i, parameters[i]);
-		}
+		this.bind(statement, parameters);
 		try {
 			var that = this;
 			var e = function (name) {

--- a/src/content/common.js
+++ b/src/content/common.js
@@ -71,7 +71,9 @@ var stylishCommon = {
 			for (var i = 0; i < browsers.length; i++) {
 				// We can't read into remote documents easily. We only work with about:, anyway.
 				if (!(browsers[i].isRemoteBrowser) && browsers[i].currentURI.schemeIs("about")) {
-					var de = browsers[i].contentDocument.documentElement;
+					let doc = browsers[i].contentDocument;
+					if (doc == null) continue;
+					let de = doc.documentElement;
 					if (de && de.getAttribute("windowtype") == name) {
 						tbWin.gBrowser.selectTabAtIndex(i);
 						tbWin.focus();
@@ -152,11 +154,11 @@ var stylishCommon = {
 		if (urls.length == 0) {
 			return;
 		}
-		
+
 		if (startedCallback) {
 			startedCallback();
 		}
-		
+
 		// Run through each one, one at a time, keeping track of successes or failures
 		var currentIndex = 0;
 		var results = {successes: [], failures: []};
@@ -172,7 +174,7 @@ var stylishCommon = {
 		}
 		stylishCommon.installFromUrl(urls[currentIndex], processResult);
 	},
-	
+
 	endInstallFromUrls: function(results, endedCallback) {
 		if (endedCallback) {
 			endedCallback();
@@ -310,7 +312,7 @@ var stylishCommon = {
 			}
 			return;
 		}
-		
+
 		function fillName(prefix) {
 			params.windowType = stylishCommon.getWindowName(prefix, params.triggeringDocument ? stylishFrameUtils.cleanURI(params.triggeringDocument.location.href) : null);
 		}

--- a/src/content/overlay.js
+++ b/src/content/overlay.js
@@ -88,22 +88,19 @@ var stylishOverlay = {
 		prefService.addObserver("extensions.stylem.styleRegistrationEnabled", stylishOverlay, false);
 
 		// style add/delete
+		stylishOverlay.TOPICS = ["stylem-style-add", "stylem-style-change", "stylem-style-delete"];
 		var observerService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
-		observerService.addObserver(stylishOverlay, "stylem-style-add", false);
-		observerService.addObserver(stylishOverlay, "stylem-style-change", false);
-		observerService.addObserver(stylishOverlay, "stylem-style-delete", false);
+		let junk = stylishOverlay.TOPICS.map((t) => observerService.addObserver(stylishOverlay, t, false));
 	},
 
 	destroy: function() {
 		if (typeof gBrowser != "undefined") {
-			gBrowser.removeProgressListener(stylishOverlay.urlLoadedListener, Components.interfaces.nsIWebProgress.NOTIFY_STATE_DOCUMENT); 
+			gBrowser.removeProgressListener(stylishOverlay.urlLoadedListener, Components.interfaces.nsIWebProgress.NOTIFY_STATE_DOCUMENT);
 		}
 		var prefService = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService).QueryInterface(Components.interfaces.nsIPrefBranch);
 		prefService.removeObserver("extensions.stylem.styleRegistrationEnabled", stylishOverlay);
 		var observerService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
-		observerService.removeObserver(stylishOverlay, "stylem-style-add");
-		observerService.removeObserver(stylishOverlay, "stylem-style-change");
-		observerService.removeObserver(stylishOverlay, "stylem-style-delete");
+		let junk = stylishOverlay.TOPICS.map((t) => observerService.removeObserver(stylishOverlay, t));
 	},
 
 	observe: function(subject, topic, data) {
@@ -118,7 +115,7 @@ var stylishOverlay = {
 				aIID.equals(Components.interfaces.nsISupportsWeakReference) ||
 				aIID.equals(Components.interfaces.nsISupports))
 				return this;
-			throw Components.results.NS_NOINTERFACE; 
+			throw Components.results.NS_NOINTERFACE;
 		},
 		onLocationChange: function(progress, request, uri) {
 			// only if it's the current tab
@@ -138,7 +135,7 @@ var stylishOverlay = {
 
 	urlUpdated: function() {
 		var uri = stylishOverlay.currentURI;
-		if (stylishOverlay.lastUrl == uri.spec)
+		if (!uri || stylishOverlay.lastUrl == uri.spec)
 			return;
 		stylishOverlay.lastUrl = uri.spec;
 		document.documentElement.setAttribute("stylem-url", uri.spec);
@@ -402,7 +399,7 @@ var stylishOverlay = {
 		if (Components.interfaces.nsIEffectiveTLDService) {
 			try {
 				var tld = Components.classes["@mozilla.org/network/effective-tld-service;1"].getService(Components.interfaces.nsIEffectiveTLDService);
-				if (Components.ID('{b07cb0f0-3394-572e-6260-dbaed0a292ba}').equals(Components.interfaces.nsIStyleSheetService)) {	
+				if (Components.ID('{b07cb0f0-3394-572e-6260-dbaed0a292ba}').equals(Components.interfaces.nsIStyleSheetService)) {
 					if (domain.length <= tld.getEffectiveTLDLength(domain)) {
 						return;
 					}
@@ -411,7 +408,7 @@ var stylishOverlay = {
 						return;
 					}
 				}
-			} catch(ex) { 
+			} catch(ex) {
 				//this can happen if it's an ip address
 				return;
 			}

--- a/src/install.rdf
+++ b/src/install.rdf
@@ -68,6 +68,9 @@
     <em:contributor>LouCypher - icons</em:contributor>
     <em:contributor>s4nji - icons</em:contributor>
     <em:contributor>Jason Barnabe</em:contributor>
+    <em:contributor>Ryan C</em:contributor>
+    <em:contributor>@dirkf</em:contributor>
+    <em:contributor>Oriol Brufau</em:contributor>
     <em:type>2</em:type>
 
     <!--Firefox-alikes-->


### PR DESCRIPTION
I forked the project to apply some fixes for SeaMonkey 2.5.13.

Now that most of those fixes have been separately merged here thanks to @UCyborg, I thought I'd offer the remaining changes from that fork.

This PR adds:
* additional changes from an [old Stylish PR](https://github.com/stylish-userstyles/stylish/pull/319/commits) (see also [here](http://forums.mozillazine.org/viewtopic.php?p=14933501&sid=0132ea8666f56cbc165e09c643a34ecb#p14933501)), other than those that are replicated by UCyborg's recently merged fixes;
* a safety fix to avoid console warnings and some simplification in `src/stylem/src/content/overlay.js`;
* a couple of documentation updates.

Not that I have a Firefox 57 at hand to check, but I believe that with these changes in places you could also apply this:
```diff
--- old/src/install.rdf
+++ new/src/install.rdf
@@ -78,7 +78,7 @@
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
         <em:minVersion>52.0</em:minVersion>
-        <em:maxVersion>52.*</em:maxVersion>
+        <em:maxVersion>57.*</em:maxVersion>
       </Description>
     </em:targetApplication>
     <!--Thunderbird-alikes-->
```